### PR TITLE
InputFieldAddedChange when adding a non-null type field with a default value is not a breaking change

### DIFF
--- a/packages/core/__tests__/diff/input.test.ts
+++ b/packages/core/__tests__/diff/input.test.ts
@@ -17,15 +17,18 @@ describe('input', () => {
           b: String!
           c: String!
           d: String
+          e: String! = "Eee"
         }
       `);
 
+      const changes = await diff(a, b);
       const change = {
-        c: findFirstChangeByPath(await diff(a, b), 'Foo.c'),
-        d: findFirstChangeByPath(await diff(a, b), 'Foo.d'),
+        c: findFirstChangeByPath(changes, 'Foo.c'),
+        d: findFirstChangeByPath(changes, 'Foo.d'),
+        e: findFirstChangeByPath(changes, 'Foo.e'),
       };
 
-      // Non-nullable
+      // Non-nullable without default
       expect(change.c.criticality.level).toEqual(CriticalityLevel.Breaking);
       expect(change.c.type).toEqual('INPUT_FIELD_ADDED');
       expect(change.c.message).toEqual(
@@ -36,6 +39,12 @@ describe('input', () => {
       expect(change.d.type).toEqual('INPUT_FIELD_ADDED');
       expect(change.d.message).toEqual(
         "Input field 'd' of type 'String' was added to input object type 'Foo'",
+      );
+      // Non-nullable with default
+      expect(change.e.criticality.level).toEqual(CriticalityLevel.Dangerous);
+      expect(change.e.type).toEqual('INPUT_FIELD_ADDED');
+      expect(change.e.message).toEqual(
+        "Input field 'e' of type 'String!' was added to input object type 'Foo'",
       );
     });
     test('removed', async () => {

--- a/packages/core/src/diff/changes/change.ts
+++ b/packages/core/src/diff/changes/change.ts
@@ -453,6 +453,8 @@ export type InputFieldAddedChange = {
     addedInputFieldName: string;
     isAddedInputFieldTypeNullable: boolean;
     addedInputFieldType: string;
+    hasDefaultValue: boolean;
+    isAddedInputFieldBreaking: boolean;
   };
 };
 

--- a/packages/core/src/diff/changes/input.ts
+++ b/packages/core/src/diff/changes/input.ts
@@ -56,14 +56,14 @@ export function buildInputFieldAddedMessage(args: InputFieldAddedChange['meta'])
 export function inputFieldAddedFromMeta(args: InputFieldAddedChange) {
   return {
     type: ChangeType.InputFieldAdded,
-    criticality: args.meta.isAddedInputFieldTypeNullable
+    criticality: args.meta.isAddedInputFieldBreaking
       ? {
-          level: CriticalityLevel.Dangerous,
-        }
-      : {
           level: CriticalityLevel.Breaking,
           reason:
             'Adding a required input field to an existing input object type is a breaking change because it will cause existing uses of this input object type to error.',
+        }
+      : {
+        level: CriticalityLevel.Dangerous,
         },
     message: buildInputFieldAddedMessage(args.meta),
     meta: args.meta,
@@ -75,6 +75,8 @@ export function inputFieldAdded(
   input: GraphQLInputObjectType,
   field: GraphQLInputField,
 ): Change<typeof ChangeType.InputFieldAdded> {
+  const isBreaking = isNonNullType(field.type) && typeof field.defaultValue === 'undefined';
+
   return inputFieldAddedFromMeta({
     type: ChangeType.InputFieldAdded,
     meta: {
@@ -82,6 +84,8 @@ export function inputFieldAdded(
       addedInputFieldName: field.name,
       isAddedInputFieldTypeNullable: !isNonNullType(field.type),
       addedInputFieldType: field.type.toString(),
+      hasDefaultValue: field.defaultValue != null,
+      isAddedInputFieldBreaking: isBreaking,
     },
   });
 }


### PR DESCRIPTION
## Description

Updated InputFieldAddedChange logic to correctly handle non-null fields with default values. Previously, adding such fields was flagged as breaking; this change ensures they are recognized as not breaking.

Fixes # (https://github.com/graphql-hive/graphql-inspector/issues/2880)

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. 
Updated [input.test.ts](https://github.com/graphql-hive/graphql-inspector/compare/master...janeli1:arcpatch-D17076739?expand=1#diff-c12207f3baa6fe8bbc727196016ba211a15f0da94c055fd6b56f5cff5ab49d94) to cover this change.

Provide instructions so we can reproduce. 
Reproduce step is provided in reported issue. 

Please also list any relevant details for your test configuration
- [ ] Test A
- [ ] Test B

**Test Environment**:

- OS:
- `@graphql-inspector/...`:
- NodeJS:
