### PR TITLE
Added Apollo Federation V2 support

### DIFF
--- a/packages/commands/commands/src/index.ts
+++ b/packages/commands/commands/src/index.ts
@@ -38,6 +38,7 @@ export interface GlobalArgs {
   leftHeader?: string[];
   rightHeader?: string[];
   federation?: boolean;
+  federationV2?: boolean;
   aws?: boolean;
   method?: string;
 }

--- a/packages/commands/coverage/src/index.ts
+++ b/packages/commands/coverage/src/index.ts
@@ -106,6 +106,7 @@ export default createCommand<
       const silent = args.silent;
       const { headers, token } = parseGlobalArgs(args);
       const apolloFederation = args.federation || false;
+      const apolloFederationV2 = args.federationV2 || false;
       const aws = args.aws || false;
       const method = args.method?.toUpperCase() || 'POST';
 
@@ -117,6 +118,7 @@ export default createCommand<
           method,
         },
         apolloFederation,
+        apolloFederationV2,
         aws,
       );
       const documents = await loaders.loadDocuments(args.documents);

--- a/packages/commands/diff/src/index.ts
+++ b/packages/commands/diff/src/index.ts
@@ -130,6 +130,7 @@ export default createCommand<
         const oldSchemaPointer = args.oldSchema;
         const newSchemaPointer = args.newSchema;
         const apolloFederation = args.federation || false;
+        const apolloFederationV2 = args.federationV2 || false;
         const aws = args.aws || false;
         const method = args.method?.toUpperCase() || 'POST';
         const { headers, leftHeaders, rightHeaders, token } = parseGlobalArgs(args);
@@ -151,6 +152,7 @@ export default createCommand<
             method,
           },
           apolloFederation,
+          apolloFederationV2,
           aws,
         );
         const newSchema = await loaders.loadSchema(
@@ -161,6 +163,7 @@ export default createCommand<
             method,
           },
           apolloFederation,
+          apolloFederationV2,
           aws,
         );
 

--- a/packages/commands/introspect/src/index.ts
+++ b/packages/commands/introspect/src/index.ts
@@ -89,6 +89,7 @@ export default createCommand<
       const output = args.write!;
       const comments = args.comments || false;
       const apolloFederation = args.federation || false;
+      const apolloFederationV2 = args.federationV2 || false;
       const aws = args.aws || false;
       const method = args.method?.toUpperCase() || 'POST';
 
@@ -100,6 +101,7 @@ export default createCommand<
           method,
         },
         apolloFederation,
+        apolloFederationV2,
         aws,
       );
 

--- a/packages/commands/serve/src/index.ts
+++ b/packages/commands/serve/src/index.ts
@@ -43,6 +43,7 @@ export default createCommand<
     async handler(args) {
       const { headers, token } = parseGlobalArgs(args);
       const apolloFederation = args.federation || false;
+      const apolloFederationV2 = args.federationV2 || false;
       const aws = args.aws || false;
       const method = args.method?.toUpperCase() || 'POST';
 
@@ -54,6 +55,7 @@ export default createCommand<
           method,
         },
         apolloFederation,
+        apolloFederationV2,
         aws,
       );
 

--- a/packages/commands/similar/src/index.ts
+++ b/packages/commands/similar/src/index.ts
@@ -117,6 +117,7 @@ export default createCommand<
       const type = args.name;
       const threshold = args.threshold;
       const apolloFederation = args.federation || false;
+      const apolloFederationV2 = args.federationV2 || false;
       const aws = args.aws || false;
       const method = args.method?.toUpperCase() || 'POST';
 
@@ -128,6 +129,7 @@ export default createCommand<
           method,
         },
         apolloFederation,
+        apolloFederationV2,
         aws,
       );
 

--- a/packages/commands/validate/src/index.ts
+++ b/packages/commands/validate/src/index.ts
@@ -278,6 +278,8 @@ export default createCommand<
       const apollo = args.apollo || false;
       const aws = args.aws || false;
       const apolloFederation = args.federation || false;
+      const apolloFederationV2 = args.federationV2 || false;
+
       const method = args.method?.toUpperCase() || 'POST';
       const maxDepth = args.maxDepth == null ? undefined : args.maxDepth;
       const maxAliasCount = args.maxAliasCount == null ? undefined : args.maxAliasCount;
@@ -311,6 +313,7 @@ export default createCommand<
           method,
         },
         apolloFederation,
+        apolloFederationV2,
         aws,
       );
       const documents = await loaders.loadDocuments(args.documents, {

--- a/packages/core/__tests__/validate/apollo-federation-v2.test.ts
+++ b/packages/core/__tests__/validate/apollo-federation-v2.test.ts
@@ -1,0 +1,449 @@
+import { parse, print, Source } from 'graphql';
+import { LoadersRegistry } from '@graphql-inspector/loaders';
+import { validate } from '../../src/index.js';
+
+describe('apollo federation v2', () => {
+  test('should accept basic Federation V2 directives', async () => {
+    const doc = parse(/* GraphQL */ `
+      query getUser {
+        user(id: "1") {
+          id
+          name
+          email
+          orders {
+            id
+            total
+          }
+        }
+      }
+    `);
+
+    const schema = await new LoadersRegistry().loadSchema(
+      /* GraphQL */ `
+        type User @key(fields: "id") {
+          id: ID!
+          name: String!
+          email: String!
+          orders: [Order!]! @external
+        }
+
+        type Order @key(fields: "id") {
+          id: ID!
+          total: Float!
+          user: User! @external
+        }
+
+        type Query {
+          user(id: ID!): User
+        }
+      `,
+      {},
+      false,
+      true,
+      false,
+    );
+
+    const results = validate(schema, [new Source(print(doc))]);
+
+    expect(results).toHaveLength(0);
+  });
+
+  test('should accept @shareable directive on fields', async () => {
+    const doc = parse(/* GraphQL */ `
+      query getProduct {
+        product(id: "1") {
+          id
+          name
+          description
+        }
+      }
+    `);
+
+    const schema = await new LoadersRegistry().loadSchema(
+      /* GraphQL */ `
+        extend schema
+          @link(
+            url: "https://specs.apollographql.com/federation/v2.3"
+            import: ["@key", "@shareable"]
+          )
+
+        type Product @key(fields: "id") {
+          id: ID!
+          name: String! @shareable
+          description: String @shareable
+        }
+
+        type Query {
+          product(id: ID!): Product
+        }
+      `,
+      {},
+      false,
+      true,
+      false,
+    );
+
+    const results = validate(schema, [new Source(print(doc))]);
+
+    expect(results).toHaveLength(0);
+  });
+
+  test('should accept @requires and @provides directives', async () => {
+    const doc = parse(/* GraphQL */ `
+      query getUserWithShippingEstimate {
+        user(id: "1") {
+          id
+          shippingEstimate
+          cart {
+            estimatedDelivery
+          }
+        }
+      }
+    `);
+
+    const schema = await new LoadersRegistry().loadSchema(
+      /* GraphQL */ `
+        extend schema
+          @link(
+            url: "https://specs.apollographql.com/federation/v2.3"
+            import: ["@key", "@external", "@requires", "@provides"]
+          )
+
+        type User @key(fields: "id") {
+          id: ID!
+          zipCode: String @external
+          shippingEstimate: String @requires(fields: "zipCode")
+          cart: Cart @provides(fields: "estimatedDelivery")
+        }
+
+        type Cart {
+          estimatedDelivery: String @external
+        }
+
+        type Query {
+          user(id: ID!): User
+        }
+      `,
+      {},
+      false,
+      true,
+      false,
+    );
+
+    const results = validate(schema, [new Source(print(doc))]);
+
+    expect(results).toHaveLength(0);
+  });
+
+  test('should accept @override directive', async () => {
+    const doc = parse(/* GraphQL */ `
+      query getAccount {
+        account(id: "1") {
+          id
+          balance
+          currency
+        }
+      }
+    `);
+
+    const schema = await new LoadersRegistry().loadSchema(
+      /* GraphQL */ `
+        extend schema
+          @link(
+            url: "https://specs.apollographql.com/federation/v2.3"
+            import: ["@key", "@override"]
+          )
+
+        type Account @key(fields: "id") {
+          id: ID!
+          balance: Float! @override(from: "accounts")
+          currency: String!
+        }
+
+        type Query {
+          account(id: ID!): Account
+        }
+      `,
+      {},
+      false,
+      true,
+      false,
+    );
+
+    const results = validate(schema, [new Source(print(doc))]);
+
+    expect(results).toHaveLength(0);
+  });
+
+  test('should accept @inaccessible directive', async () => {
+    const doc = parse(/* GraphQL */ `
+      query getUser {
+        user(id: "1") {
+          id
+          name
+        }
+      }
+    `);
+
+    const schema = await new LoadersRegistry().loadSchema(
+      /* GraphQL */ `
+        extend schema
+          @link(
+            url: "https://specs.apollographql.com/federation/v2.3"
+            import: ["@key", "@inaccessible"]
+          )
+
+        type User @key(fields: "id") {
+          id: ID!
+          name: String!
+          internalId: String @inaccessible
+        }
+
+        type Query {
+          user(id: ID!): User
+        }
+      `,
+      {},
+      false,
+      true,
+      false,
+    );
+
+    const results = validate(schema, [new Source(print(doc))]);
+
+    expect(results).toHaveLength(0);
+  });
+
+  test('should accept @tag directive', async () => {
+    const doc = parse(/* GraphQL */ `
+      query getProduct {
+        product(id: "1") {
+          id
+          name
+          price
+        }
+      }
+    `);
+
+    const schema = await new LoadersRegistry().loadSchema(
+      /* GraphQL */ `
+        extend schema
+          @link(url: "https://specs.apollographql.com/federation/v2.3", import: ["@key", "@tag"])
+
+        type Product @key(fields: "id") {
+          id: ID!
+          name: String!
+          price: Float! @tag(name: "pricing")
+        }
+
+        type Query {
+          product(id: ID!): Product
+        }
+      `,
+      {},
+      false,
+      true,
+      false,
+    );
+
+    const results = validate(schema, [new Source(print(doc))]);
+
+    expect(results).toHaveLength(0);
+  });
+
+  test('should accept @interfaceObject directive', async () => {
+    const doc = parse(/* GraphQL */ `
+      query getEntity {
+        entity(id: "1") {
+          id
+          name
+        }
+      }
+    `);
+
+    const schema = await new LoadersRegistry().loadSchema(
+      /* GraphQL */ `
+        extend schema
+          @link(
+            url: "https://specs.apollographql.com/federation/v2.3"
+            import: ["@key", "@interfaceObject"]
+          )
+
+        type Entity @key(fields: "id") @interfaceObject {
+          id: ID!
+          name: String!
+        }
+
+        type Query {
+          entity(id: ID!): Entity
+        }
+      `,
+      {},
+      false,
+      true,
+      false,
+    );
+
+    const results = validate(schema, [new Source(print(doc))]);
+
+    expect(results).toHaveLength(0);
+  });
+
+  test('should accept @composeDirective directive', async () => {
+    const doc = parse(/* GraphQL */ `
+      query getUser {
+        user(id: "1") {
+          id
+          name
+          profile
+        }
+      }
+    `);
+
+    const schema = await new LoadersRegistry().loadSchema(
+      /* GraphQL */ `
+        extend schema
+          @link(
+            url: "https://specs.apollographql.com/federation/v2.3"
+            import: ["@key", "@composeDirective"]
+          )
+          @composeDirective(name: "@custom")
+
+        directive @custom(value: String) on FIELD_DEFINITION
+
+        type User @key(fields: "id") {
+          id: ID!
+          name: String!
+          profile: String @custom(value: "user-profile")
+        }
+
+        type Query {
+          user(id: ID!): User
+        }
+      `,
+      {},
+      false,
+      true,
+      false,
+    );
+
+    const results = validate(schema, [new Source(print(doc))]);
+
+    expect(results).toHaveLength(0);
+  });
+
+  test('should accept complex Federation V2 schema with multiple entities', async () => {
+    const doc = parse(/* GraphQL */ `
+      query getRecommendations {
+        user(id: "1") {
+          id
+          name
+          recommendations {
+            id
+            name
+            price
+            reviews {
+              id
+              rating
+              comment
+            }
+          }
+        }
+      }
+    `);
+
+    const schema = await new LoadersRegistry().loadSchema(
+      /* GraphQL */ `
+        extend schema
+          @link(
+            url: "https://specs.apollographql.com/federation/v2.3"
+            import: ["@key", "@external", "@requires", "@provides", "@shareable", "@tag"]
+          )
+
+        type User @key(fields: "id") {
+          id: ID!
+          name: String! @shareable
+          age: Int @external
+          recommendations: [Product!]!
+            @requires(fields: "age")
+            @provides(fields: "reviews { rating }")
+        }
+
+        type Product @key(fields: "id") {
+          id: ID!
+          name: String! @shareable
+          price: Float! @tag(name: "pricing")
+          reviews: [Review!]! @external
+        }
+
+        type Review @key(fields: "id") {
+          id: ID!
+          rating: Int @external
+          comment: String
+        }
+
+        type Query {
+          user(id: ID!): User
+        }
+      `,
+      {},
+      false,
+      true,
+      false,
+    );
+
+    const results = validate(schema, [new Source(print(doc))]);
+
+    expect(results).toHaveLength(0);
+  });
+
+  test('should handle Federation V2 with custom scalar types', async () => {
+    const doc = parse(/* GraphQL */ `
+      query getEvent {
+        event(id: "1") {
+          id
+          timestamp
+          location {
+            coordinates
+          }
+        }
+      }
+    `);
+
+    const schema = await new LoadersRegistry().loadSchema(
+      /* GraphQL */ `
+        extend schema
+          @link(
+            url: "https://specs.apollographql.com/federation/v2.3"
+            import: ["@key", "@shareable"]
+          )
+
+        scalar DateTime
+        scalar GeoCoordinates
+
+        type Event @key(fields: "id") {
+          id: ID!
+          timestamp: DateTime! @shareable
+          location: Location
+        }
+
+        type Location @key(fields: "id") {
+          id: ID!
+          coordinates: GeoCoordinates!
+        }
+
+        type Query {
+          event(id: ID!): Event
+        }
+      `,
+      {},
+      false,
+      true,
+      false,
+    );
+
+    const results = validate(schema, [new Source(print(doc))]);
+
+    expect(results).toHaveLength(0);
+  });
+});

--- a/packages/core/__tests__/validate/aws.test.ts
+++ b/packages/core/__tests__/validate/aws.test.ts
@@ -42,6 +42,7 @@ describe('aws', () => {
       `,
       {},
       false,
+      false,
       true,
     );
 

--- a/packages/loaders/loaders/src/index.ts
+++ b/packages/loaders/loaders/src/index.ts
@@ -1,4 +1,4 @@
-import { buildSchema, GraphQLSchema } from 'graphql';
+import { buildSchema, GraphQLSchema, isInterfaceType, isObjectType, printSchema } from 'graphql';
 import { InspectorConfig } from '@graphql-inspector/config';
 import {
   loadDocuments,
@@ -26,16 +26,81 @@ export class LoadersRegistry {
     }
   }
 
-  loadSchema(
+  async loadSchema(
     pointer: string,
     options: Omit<LoadSchemaOptions, 'loaders'> = {},
     enableApolloFederation: boolean,
+    enableApolloFederationV2: boolean,
     enableAWS: boolean,
   ): Promise<GraphQLSchema> {
-    return enrichError(
+    const schema = await enrichError(
       loadSchema(pointer, {
         loaders: this.loaders,
         ...options,
+        ...(enableApolloFederationV2
+          ? {
+              schemas: [
+                buildSchema(/* GraphQL */ `
+                  scalar _Any
+                  union _Entity
+                  scalar FieldSet
+                  scalar link__Import
+                  scalar federation__ContextFieldValue
+                  scalar federation__Scope
+                  scalar federation__Policy
+                  type Query
+
+                  enum link__Purpose {
+                    SECURITY
+                    EXECUTION
+                  }
+
+                  type _Service {
+                    sdl: String!
+                  }
+
+                  extend type Query {
+                    _entities(representations: [_Any!]!): [_Entity]!
+                    _service: _Service!
+                  }
+
+                  directive @external on FIELD_DEFINITION | OBJECT
+                  directive @requires(fields: FieldSet!) on FIELD_DEFINITION
+                  directive @provides(fields: FieldSet!) on FIELD_DEFINITION
+                  directive @key(
+                    fields: FieldSet!
+                    resolvable: Boolean = true
+                  ) repeatable on OBJECT | INTERFACE
+                  directive @link(
+                    url: String!
+                    as: String
+                    for: link__Purpose
+                    import: [link__Import]
+                  ) repeatable on SCHEMA
+                  directive @shareable repeatable on OBJECT | FIELD_DEFINITION
+                  directive @inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+                  directive @tag(
+                    name: String!
+                  ) repeatable on FIELD_DEFINITION | INTERFACE | OBJECT | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+                  directive @override(from: String!) on FIELD_DEFINITION
+                  directive @composeDirective(name: String!) repeatable on SCHEMA
+                  directive @interfaceObject on OBJECT
+                  directive @authenticated on FIELD_DEFINITION | OBJECT | INTERFACE | SCALAR | ENUM
+                  directive @requiresScopes(
+                    scopes: [[federation__Scope!]!]!
+                  ) on FIELD_DEFINITION | OBJECT | INTERFACE | SCALAR | ENUM
+                  directive @policy(
+                    policies: [[federation__Policy!]!]!
+                  ) on FIELD_DEFINITION | OBJECT | INTERFACE | SCALAR | ENUM
+                  directive @context(name: String!) repeatable on INTERFACE | OBJECT | UNION
+                  directive @fromContext(
+                    field: federation__ContextFieldValue
+                  ) on ARGUMENT_DEFINITION
+                  directive @extends on OBJECT | INTERFACE
+                `),
+              ],
+            }
+          : {}),
         ...(enableApolloFederation
           ? {
               schemas: [
@@ -86,6 +151,12 @@ export class LoadersRegistry {
           : {}),
       }),
     );
+
+    if (enableApolloFederationV2) {
+      return this.buildEntityUnion(schema);
+    }
+
+    return schema;
   }
 
   loadDocuments(
@@ -98,6 +169,33 @@ export class LoadersRegistry {
         ...options,
       }),
     );
+  }
+
+  private buildEntityUnion(schema: GraphQLSchema): GraphQLSchema {
+    const entityTypes: string[] = [];
+    const typeMap = schema.getTypeMap();
+
+    // Find all types with @key directive
+    Object.values(typeMap).forEach(type => {
+      if (
+        (isObjectType(type) || isInterfaceType(type)) &&
+        type.astNode?.directives?.some(dir => dir.name.value === 'key')
+      ) {
+        entityTypes.push(type.name);
+      }
+    });
+
+    if (entityTypes.length === 0) {
+      return schema; // No entities found
+    }
+
+    // Create new schema SDL with populated _Entity union
+    const entityUnion = `union _Entity = ${entityTypes.join(' | ')}`;
+
+    // Rebuild schema with proper _Entity union
+    const schemaSDL = printSchema(schema).replace('union _Entity', entityUnion);
+
+    return buildSchema(schemaSDL);
   }
 }
 


### PR DESCRIPTION
## Description

GraphQL Inspector don't support Federation V2. This PR adds the directives as well as a new argument `--federationV2` to support this functionality.

Will add the necessary documentation if implementation is ok.

Fixes # (issue)
https://github.com/graphql-hive/graphql-inspector/issues/2683

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] This change requires a documentation update

## How Has This Been Tested?

- [ ] Added unit tests for the loader
- [ ] This code is used in our main pipeline

**Test Environment**:

- OS: Mac
- `@graphql-inspector/...`:
- NodeJS: v22.19.0

## Checklist:

- [X] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
